### PR TITLE
A routine for casting schemas down to plain objects

### DIFF
--- a/src/schemaToObject.js
+++ b/src/schemaToObject.js
@@ -1,0 +1,26 @@
+const { analyze } = require("./PropTypeAnalyzer");
+
+// Gives us a primitive form of a schema node that we can use with
+// Object.whitelist and other schema-based utils.
+function schemaToObject(node) {
+  if (node.type === "shape") {
+    return node.properties.reduce(function(hsh, entry) {
+      hsh[entry.name] = schemaToObject(entry);
+
+      return hsh;
+    }, {});
+  }
+  else if (node.type === "arrayOf") {
+    return [ schemaToObject(node.element) ];
+  }
+  else if (node.type === "literal") {
+    return node.value !== undefined ? node.value : null;
+  }
+  else {
+    return null;
+  }
+}
+
+module.exports = function(rootNode) {
+  return schemaToObject(analyze(rootNode));
+};

--- a/test/schemaToObject.test.js
+++ b/test/schemaToObject.test.js
@@ -1,0 +1,59 @@
+import subject from '../src/schemaToObject';
+import { arrayOf, shape, string, bool } from '../src/PropTypes';
+import { expect } from 'chai';
+
+describe('utils::schemaToObject', function() {
+  describe('converting shapes to objects', function() {
+    it('works with an empty shape', function() {
+      expect(subject(shape({}))).to.deep.equal({});
+    });
+
+    it('works with a shape containing some literal properties', function() {
+      expect(subject(shape({ name: string }))).to.deep.equal({ name: 'string' });
+    });
+
+    it('works with nested shapes', function() {
+      const schema = shape({
+        id: string,
+        user: shape({
+          id: string
+        })
+      });
+
+      expect(subject(schema)).to.deep.equal({
+        id: 'string',
+        user: {
+          id: 'string'
+        }
+      });
+    });
+  });
+
+  describe('converting arrayOf to arrays', function() {
+    it('works with a literal as an element type', function() {
+      expect(subject(arrayOf(string))).to.deep.equal(['string']);
+    });
+
+    it('works with a shape as an element type', function() {
+      expect(
+        subject(arrayOf(shape({ id: string })))
+      ).to.deep.equal(
+        [{ id: 'string' }]
+      );
+    });
+
+    it('works with bools', function() {
+      expect(
+        subject(arrayOf(bool))
+      ).to.deep.equal(
+        ['bool']
+      );
+    });
+  });
+
+  it('leaves "null" fields untouched', function() {
+    expect(subject(shape({ __emberModel__: null }))).to.deep.equal({
+      __emberModel__: null
+    });
+  });
+});


### PR DESCRIPTION
schemaToObject(s: Function) -> Object

Takes something like an introspectable PropTypes.shape() and yields a
plain object that describes the structure of that schema so that
consumers don't have to fiddle with the introspection internals.
