### PR TITLE
Remove React dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,11 @@ React provides an extraordinarily concise yet powerful way of defining component
 Validate an object against an API definition:
 
 ```js
-import React from "react";
-import schema from "react-schema";
+import schema, { PropTypes } from "react-schema";
 
 // An API schema.
 const mySchema = {
-  isEnabled: React.PropTypes.bool.isRequired,
+  isEnabled: PropTypes.bool.isRequired,
   width: PropTypes.numberOrString,
 };
 

--- a/package.json
+++ b/package.json
@@ -12,10 +12,9 @@
     "prepublish": "npm test && npm run lint && npm run build"
   },
   "devDependencies": {
+    "chai": "^3.5.0",
     "js-babel": "^6.0.6",
     "js-babel-dev": "^6.0.7",
-    "react": "^15.1.0",
-    "chai": "^3.5.0",
     "mocha": "^2.5.3"
   },
   "repository": {
@@ -23,7 +22,10 @@
     "url": "https://github.com/philcockfield/react-schema"
   },
   "keywords": [
-    "react", "schema", "validation", "util"
+    "react",
+    "schema",
+    "validation",
+    "util"
   ],
   "author": {
     "name": "Phil Cockfield",

--- a/src/PropTypes.js
+++ b/src/PropTypes.js
@@ -1,23 +1,23 @@
 const clone = require('./utils/clone');
 const createIntrospectableChecker = require('./utils/createIntrospectableChecker');
-const React = require('react');
-const PropTypes = clone(React.PropTypes);
+const ReactPropTypes = require('./ReactPropTypes');
+const PropTypes = clone(ReactPropTypes);
 
 /**
  * Common combinations of types.
  */
 PropTypes.numberOrString = PropTypes.oneOfType([
-  React.PropTypes.number,
-  React.PropTypes.string,
+  ReactPropTypes.number,
+  ReactPropTypes.string,
 ]);
 
 PropTypes.boolOrString = PropTypes.oneOfType([
-  React.PropTypes.bool,
-  React.PropTypes.string,
+  ReactPropTypes.bool,
+  ReactPropTypes.string,
 ]);
 
 ['shape', 'arrayOf', 'oneOf', 'oneOfType'].forEach(type => {
-  PropTypes[type] = createIntrospectableChecker(type, React.PropTypes[type]);
+  PropTypes[type] = createIntrospectableChecker(type, ReactPropTypes[type]);
 });
 
 // ----------------------------------------------------------------------------

--- a/src/ReactPropTypes.js
+++ b/src/ReactPropTypes.js
@@ -1,0 +1,468 @@
+/* eslint-disable */
+/**
+ * Copyright 2013-2015, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule ReactPropTypes
+ */
+
+'use strict';
+
+
+// The Symbol used to tag the ReactElement type. If there is no native Symbol
+// nor polyfill, then a plain number is used for performance.
+var REACT_ELEMENT_TYPE =
+  (typeof Symbol === 'function' && Symbol.for && Symbol.for('react.element')) ||
+  0xeac7;
+
+var ReactElement = {};
+
+/**
+ * @param {?object} object
+ * @return {boolean} True if `object` is a valid component.
+ * @final
+ */
+ReactElement.isValidElement = function(object) {
+  return (
+    typeof object === 'object' &&
+    object !== null &&
+    object.$$typeof === REACT_ELEMENT_TYPE
+  );
+};
+
+var ReactPropTypeLocationNames = {
+  prop: 'prop',
+  context: 'context',
+  childContext: 'child context',
+};
+
+
+
+
+var emptyFunction = {
+  thatReturns: function(what) {
+    return function(){ return what; };
+  }
+};
+
+
+
+var ITERATOR_SYMBOL = typeof Symbol === 'function' && Symbol.iterator;
+var FAUX_ITERATOR_SYMBOL = '@@iterator'; // Before Symbol spec.
+function getIteratorFn(maybeIterable) {
+  var iteratorFn = maybeIterable && (
+    (ITERATOR_SYMBOL && maybeIterable[ITERATOR_SYMBOL]) ||
+    maybeIterable[FAUX_ITERATOR_SYMBOL]
+  );
+  if (typeof iteratorFn === 'function') {
+    return iteratorFn;
+  }
+}
+
+
+
+/**
+ * Collection of methods that allow declaration and validation of props that are
+ * supplied to React components. Example usage:
+ *
+ *   var Props = require('ReactPropTypes');
+ *   var MyArticle = React.createClass({
+ *     propTypes: {
+ *       // An optional string prop named "description".
+ *       description: Props.string,
+ *
+ *       // A required enum prop named "category".
+ *       category: Props.oneOf(['News','Photos']).isRequired,
+ *
+ *       // A prop named "dialog" that requires an instance of Dialog.
+ *       dialog: Props.instanceOf(Dialog).isRequired
+ *     },
+ *     render: function() { ... }
+ *   });
+ *
+ * A more formal specification of how these methods are used:
+ *
+ *   type := array|bool|func|object|number|string|oneOf([...])|instanceOf(...)
+ *   decl := ReactPropTypes.{type}(.isRequired)?
+ *
+ * Each and every declaration produces a function with the same signature. This
+ * allows the creation of custom validation functions. For example:
+ *
+ *  var MyLink = React.createClass({
+ *    propTypes: {
+ *      // An optional string or URI prop named "href".
+ *      href: function(props, propName, componentName) {
+ *        var propValue = props[propName];
+ *        if (propValue != null && typeof propValue !== 'string' &&
+ *            !(propValue instanceof URI)) {
+ *          return new Error(
+ *            'Expected a string or an URI for ' + propName + ' in ' +
+ *            componentName
+ *          );
+ *        }
+ *      }
+ *    },
+ *    render: function() {...}
+ *  });
+ *
+ * @internal
+ */
+
+var ANONYMOUS = '<<anonymous>>';
+
+var ReactPropTypes = {
+  array: createPrimitiveTypeChecker('array'),
+  bool: createPrimitiveTypeChecker('boolean'),
+  func: createPrimitiveTypeChecker('function'),
+  number: createPrimitiveTypeChecker('number'),
+  object: createPrimitiveTypeChecker('object'),
+  string: createPrimitiveTypeChecker('string'),
+  symbol: createPrimitiveTypeChecker('symbol'),
+
+  any: createAnyTypeChecker(),
+  arrayOf: createArrayOfTypeChecker,
+  element: createElementTypeChecker(),
+  instanceOf: createInstanceTypeChecker,
+  node: createNodeChecker(),
+  objectOf: createObjectOfTypeChecker,
+  oneOf: createEnumTypeChecker,
+  oneOfType: createUnionTypeChecker,
+  shape: createShapeTypeChecker,
+};
+
+function createChainableTypeChecker(validate) {
+  function checkType(
+    isRequired,
+    props,
+    propName,
+    componentName,
+    location,
+    propFullName
+  ) {
+    componentName = componentName || ANONYMOUS;
+    propFullName = propFullName || propName;
+    if (props[propName] == null) {
+      var locationName = ReactPropTypeLocationNames[location];
+      if (isRequired) {
+        return new Error(
+          `Required ${locationName} \`${propFullName}\` was not specified in ` +
+          `\`${componentName}\`.`
+        );
+      }
+      return null;
+    } else {
+      return validate(props, propName, componentName, location, propFullName);
+    }
+  }
+
+  var chainedCheckType = checkType.bind(null, false);
+  chainedCheckType.isRequired = checkType.bind(null, true);
+
+  return chainedCheckType;
+}
+
+function createPrimitiveTypeChecker(expectedType) {
+  function validate(props, propName, componentName, location, propFullName) {
+    var propValue = props[propName];
+    var propType = getPropType(propValue);
+    if (propType !== expectedType) {
+      var locationName = ReactPropTypeLocationNames[location];
+      // `propValue` being instance of, say, date/regexp, pass the 'object'
+      // check, but we can offer a more precise error message here rather than
+      // 'of type `object`'.
+      var preciseType = getPreciseType(propValue);
+
+      return new Error(
+        `Invalid ${locationName} \`${propFullName}\` of type ` +
+        `\`${preciseType}\` supplied to \`${componentName}\`, expected ` +
+        `\`${expectedType}\`.`
+      );
+    }
+    return null;
+  }
+  return createChainableTypeChecker(validate);
+}
+
+function createAnyTypeChecker() {
+  return createChainableTypeChecker(emptyFunction.thatReturns(null));
+}
+
+function createArrayOfTypeChecker(typeChecker) {
+  function validate(props, propName, componentName, location, propFullName) {
+    var propValue = props[propName];
+    if (!Array.isArray(propValue)) {
+      var locationName = ReactPropTypeLocationNames[location];
+      var propType = getPropType(propValue);
+      return new Error(
+        `Invalid ${locationName} \`${propFullName}\` of type ` +
+        `\`${propType}\` supplied to \`${componentName}\`, expected an array.`
+      );
+    }
+    for (var i = 0; i < propValue.length; i++) {
+      var error = typeChecker(
+        propValue,
+        i,
+        componentName,
+        location,
+        `${propFullName}[${i}]`
+      );
+      if (error instanceof Error) {
+        return error;
+      }
+    }
+    return null;
+  }
+  return createChainableTypeChecker(validate);
+}
+
+function createElementTypeChecker() {
+  function validate(props, propName, componentName, location, propFullName) {
+    if (!ReactElement.isValidElement(props[propName])) {
+      var locationName = ReactPropTypeLocationNames[location];
+      return new Error(
+        `Invalid ${locationName} \`${propFullName}\` supplied to ` +
+        `\`${componentName}\`, expected a single ReactElement.`
+      );
+    }
+    return null;
+  }
+  return createChainableTypeChecker(validate);
+}
+
+function createInstanceTypeChecker(expectedClass) {
+  function validate(props, propName, componentName, location, propFullName) {
+    if (!(props[propName] instanceof expectedClass)) {
+      var locationName = ReactPropTypeLocationNames[location];
+      var expectedClassName = expectedClass.name || ANONYMOUS;
+      var actualClassName = getClassName(props[propName]);
+      return new Error(
+        `Invalid ${locationName} \`${propFullName}\` of type ` +
+        `\`${actualClassName}\` supplied to \`${componentName}\`, expected ` +
+        `instance of \`${expectedClassName}\`.`
+      );
+    }
+    return null;
+  }
+  return createChainableTypeChecker(validate);
+}
+
+function createEnumTypeChecker(expectedValues) {
+  if (!Array.isArray(expectedValues)) {
+    return createChainableTypeChecker(function() {
+      return new Error(
+        `Invalid argument supplied to oneOf, expected an instance of array.`
+      );
+    });
+  }
+
+  function validate(props, propName, componentName, location, propFullName) {
+    var propValue = props[propName];
+    for (var i = 0; i < expectedValues.length; i++) {
+      if (propValue === expectedValues[i]) {
+        return null;
+      }
+    }
+
+    var locationName = ReactPropTypeLocationNames[location];
+    var valuesString = JSON.stringify(expectedValues);
+    return new Error(
+      `Invalid ${locationName} \`${propFullName}\` of value \`${propValue}\` ` +
+      `supplied to \`${componentName}\`, expected one of ${valuesString}.`
+    );
+  }
+  return createChainableTypeChecker(validate);
+}
+
+function createObjectOfTypeChecker(typeChecker) {
+  function validate(props, propName, componentName, location, propFullName) {
+    var propValue = props[propName];
+    var propType = getPropType(propValue);
+    if (propType !== 'object') {
+      var locationName = ReactPropTypeLocationNames[location];
+      return new Error(
+        `Invalid ${locationName} \`${propFullName}\` of type ` +
+        `\`${propType}\` supplied to \`${componentName}\`, expected an object.`
+      );
+    }
+    for (var key in propValue) {
+      if (propValue.hasOwnProperty(key)) {
+        var error = typeChecker(
+          propValue,
+          key,
+          componentName,
+          location,
+          `${propFullName}.${key}`
+        );
+        if (error instanceof Error) {
+          return error;
+        }
+      }
+    }
+    return null;
+  }
+  return createChainableTypeChecker(validate);
+}
+
+function createUnionTypeChecker(arrayOfTypeCheckers) {
+  if (!Array.isArray(arrayOfTypeCheckers)) {
+    return createChainableTypeChecker(function() {
+      return new Error(
+        `Invalid argument supplied to oneOfType, expected an instance of array.`
+      );
+    });
+  }
+
+  function validate(props, propName, componentName, location, propFullName) {
+    for (var i = 0; i < arrayOfTypeCheckers.length; i++) {
+      var checker = arrayOfTypeCheckers[i];
+      if (
+        checker(props, propName, componentName, location, propFullName) == null
+      ) {
+        return null;
+      }
+    }
+
+    var locationName = ReactPropTypeLocationNames[location];
+    return new Error(
+      `Invalid ${locationName} \`${propFullName}\` supplied to ` +
+      `\`${componentName}\`.`
+    );
+  }
+  return createChainableTypeChecker(validate);
+}
+
+function createNodeChecker() {
+  function validate(props, propName, componentName, location, propFullName) {
+    if (!isNode(props[propName])) {
+      var locationName = ReactPropTypeLocationNames[location];
+      return new Error(
+        `Invalid ${locationName} \`${propFullName}\` supplied to ` +
+        `\`${componentName}\`, expected a ReactNode.`
+      );
+    }
+    return null;
+  }
+  return createChainableTypeChecker(validate);
+}
+
+function createShapeTypeChecker(shapeTypes) {
+  function validate(props, propName, componentName, location, propFullName) {
+    var propValue = props[propName];
+    var propType = getPropType(propValue);
+    if (propType !== 'object') {
+      var locationName = ReactPropTypeLocationNames[location];
+      return new Error(
+        `Invalid ${locationName} \`${propFullName}\` of type \`${propType}\` ` +
+        `supplied to \`${componentName}\`, expected \`object\`.`
+      );
+    }
+    for (var key in shapeTypes) {
+      var checker = shapeTypes[key];
+      if (!checker) {
+        continue;
+      }
+      var error = checker(
+        propValue,
+        key,
+        componentName,
+        location,
+        `${propFullName}.${key}`
+      );
+      if (error) {
+        return error;
+      }
+    }
+    return null;
+  }
+  return createChainableTypeChecker(validate);
+}
+
+function isNode(propValue) {
+  switch (typeof propValue) {
+    case 'number':
+    case 'string':
+    case 'undefined':
+      return true;
+    case 'boolean':
+      return !propValue;
+    case 'object':
+      if (Array.isArray(propValue)) {
+        return propValue.every(isNode);
+      }
+      if (propValue === null || ReactElement.isValidElement(propValue)) {
+        return true;
+      }
+
+      var iteratorFn = getIteratorFn(propValue);
+      if (iteratorFn) {
+        var iterator = iteratorFn.call(propValue);
+        var step;
+        if (iteratorFn !== propValue.entries) {
+          while (!(step = iterator.next()).done) {
+            if (!isNode(step.value)) {
+              return false;
+            }
+          }
+        } else {
+          // Iterator will provide entry [k,v] tuples rather than values.
+          while (!(step = iterator.next()).done) {
+            var entry = step.value;
+            if (entry) {
+              if (!isNode(entry[1])) {
+                return false;
+              }
+            }
+          }
+        }
+      } else {
+        return false;
+      }
+
+      return true;
+    default:
+      return false;
+  }
+}
+
+// Equivalent of `typeof` but with special handling for array and regexp.
+function getPropType(propValue) {
+  var propType = typeof propValue;
+  if (Array.isArray(propValue)) {
+    return 'array';
+  }
+  if (propValue instanceof RegExp) {
+    // Old webkits (at least until Android 4.0) return 'function' rather than
+    // 'object' for typeof a RegExp. We'll normalize this here so that /bla/
+    // passes PropTypes.object.
+    return 'object';
+  }
+  return propType;
+}
+
+// This handles more types than `getPropType`. Only used for error messages.
+// See `createPrimitiveTypeChecker`.
+function getPreciseType(propValue) {
+  var propType = getPropType(propValue);
+  if (propType === 'object') {
+    if (propValue instanceof Date) {
+      return 'date';
+    } else if (propValue instanceof RegExp) {
+      return 'regexp';
+    }
+  }
+  return propType;
+}
+
+// Returns class name of the object, if any.
+function getClassName(propValue) {
+  if (!propValue.constructor || !propValue.constructor.name) {
+    return ANONYMOUS;
+  }
+  return propValue.constructor.name;
+}
+
+module.exports = ReactPropTypes;

--- a/src/utils/getTypeName.js
+++ b/src/utils/getTypeName.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from '../PropTypes';
 
 
@@ -21,10 +20,8 @@ const getTypeName = (checker) => {
   let typeName;
 
   // Maybe this is a primitive checker?
-  Object.keys(React.PropTypes).some(key => {
+  Object.keys(PropTypes).some(key => {
     if (
-      (React.PropTypes[key] === checker) ||
-      (React.PropTypes[key] && React.PropTypes[key].isRequired === checker) ||
       (PropTypes[key] === checker) ||
       (PropTypes[key] && PropTypes[key].isRequired === checker)
     ) {

--- a/test/PropTypeAnalyzer.test.js
+++ b/test/PropTypeAnalyzer.test.js
@@ -1,42 +1,41 @@
-import React from "react";
-import { expect } from "chai";
-import { format } from "../src/PropTypeFormatter";
-import PropTypes from "../src/PropTypes";
-import { analyze } from "../src/PropTypeAnalyzer";
+import { expect } from 'chai';
+import { format } from '../src/PropTypeFormatter';
+import PropTypes from '../src/PropTypes';
+import { analyze } from '../src/PropTypeAnalyzer';
 
-describe("PropTypeAnalyzer", () => {
-  context('given a non-introspectable type checker', function() {
-    it('returns a literal node', function() {
-      expect(analyze(React.PropTypes.string)).to.deep.equal({
-        type: 'literal',
-        value: 'string'
-      });
-    });
-  });
-
-  context('given a null for a checker', function() {
-    it('returns a literal node with a null for a value', function() {
-      expect(analyze(null)).to.deep.equal({
-        type: 'literal',
-        value: null
-      });
-    });
-  });
-
-  context('given a REQUIRED non-introspectable type checker', function() {
-    it('returns a literal node', function() {
-      expect(analyze(React.PropTypes.string.isRequired)).to.deep.equal({
+describe('PropTypeAnalyzer', () => {
+  context('given a non-introspectable type checker', function () {
+    it('returns a literal node', function () {
+      expect(analyze(PropTypes.string)).to.deep.equal({
         type: 'literal',
         value: 'string',
-        isRequired: true
       });
     });
   });
 
-  describe("PropTypes.shape", () => {
-    it('generates the AST', function() {
+  context('given a null for a checker', function () {
+    it('returns a literal node with a null for a value', function () {
+      expect(analyze(null)).to.deep.equal({
+        type: 'literal',
+        value: null,
+      });
+    });
+  });
+
+  context('given a REQUIRED non-introspectable type checker', function () {
+    it('returns a literal node', function () {
+      expect(analyze(PropTypes.string.isRequired)).to.deep.equal({
+        type: 'literal',
+        value: 'string',
+        isRequired: true,
+      });
+    });
+  });
+
+  describe('PropTypes.shape', () => {
+    it('generates the AST', function () {
       const shape = PropTypes.shape({
-        name: PropTypes.string
+        name: PropTypes.string,
       });
 
       const ast = analyze(shape);
@@ -50,9 +49,9 @@ describe("PropTypeAnalyzer", () => {
       expect(ast.properties[0].value).to.equal('string');
     });
 
-    it('works with isRequired', function() {
+    it('works with isRequired', function () {
       const shape = PropTypes.shape({
-        name: PropTypes.string
+        name: PropTypes.string,
       }).isRequired;
 
       const ast = analyze(shape);
@@ -61,11 +60,11 @@ describe("PropTypeAnalyzer", () => {
       expect(ast.isRequired).to.equal(true);
     });
 
-    it('works with nested shapes', function() {
+    it('works with nested shapes', function () {
       const shape = PropTypes.shape({
         links: PropTypes.shape({
-          next: PropTypes.string
-        })
+          next: PropTypes.string,
+        }),
       });
 
       const ast = analyze(shape);
@@ -80,8 +79,8 @@ describe("PropTypeAnalyzer", () => {
     });
   });
 
-  describe("PropTypes.arrayOf", function() {
-    it('generates the AST', function() {
+  describe('PropTypes.arrayOf', function () {
+    it('generates the AST', function () {
       const propType = PropTypes.arrayOf(PropTypes.string);
       const ast = analyze(propType);
 
@@ -93,9 +92,9 @@ describe("PropTypeAnalyzer", () => {
     });
   });
 
-  describe("PropTypes.oneOfType", function() {
-    it('generates an AST', function() {
-      const propType = PropTypes.oneOfType([ PropTypes.string, PropTypes.number ]);
+  describe('PropTypes.oneOfType', function () {
+    it('generates an AST', function () {
+      const propType = PropTypes.oneOfType([PropTypes.string, PropTypes.number]);
       const ast = analyze(propType);
 
       expect(ast.type).to.equal('oneOfType');

--- a/test/PropTypeFormatter.test.js
+++ b/test/PropTypeFormatter.test.js
@@ -1,45 +1,44 @@
-import React from "react";
-import { expect } from "chai";
-import { format } from "../src/PropTypeFormatter";
-import PropTypes from "../src/PropTypes";
+import { expect } from 'chai';
+import { format } from '../src/PropTypeFormatter';
+import PropTypes from '../src/PropTypes';
 
-describe("PropTypeFormatter", () => {
-  context('given a regular React.PropTypes.something', function() {
-    it('returns the name of the checker', function() {
-      expect(format(React.PropTypes.string)).to.equal('string');
+describe('PropTypeFormatter', () => {
+  context('given a regular PropTypes.something', function () {
+    it('returns the name of the checker', function () {
+      expect(format(PropTypes.string)).to.equal('string');
     });
   });
 
-  context('given an unknown type', function() {
-    it('returns undefined', function() {
-      expect(format(React.PropTypes.asdfasdfasdf)).to.equal(undefined);
+  context('given an unknown type', function () {
+    it('returns undefined', function () {
+      expect(format(PropTypes.asdfasdfasdf)).to.equal(undefined);
     });
   });
 
-  context("given a PropTypes.oneOf", () => {
-    it("works", () => {
+  context('given a PropTypes.oneOf', () => {
+    it('works', () => {
       const result = PropTypes.oneOf(['one', 'two']);
-      expect(format(result)).to.equal("oneOf(one, two)");
+      expect(format(result)).to.equal('oneOf(one, two)');
     });
   });
 
-  context("given a PropTypes.oneOfType", () => {
-    it("works", () => {
-      const result = PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.number]);
-      expect(format(result)).to.equal("oneOfType(string, number)");
+  context('given a PropTypes.oneOfType', () => {
+    it('works', () => {
+      const result = PropTypes.oneOfType([PropTypes.string, PropTypes.number]);
+      expect(format(result)).to.equal('oneOfType(string, number)');
     });
   });
 
-  context("given a PropTypes.shape", () => {
-    it("works", () => {
+  context('given a PropTypes.shape', () => {
+    it('works', () => {
       const result = PropTypes.shape({
         isEnabled: PropTypes.bool,
         foo: {
-          total: React.PropTypes.number,
-        }
+          total: PropTypes.number,
+        },
       });
 
-      expect(format(result)).to.equal("shape({isEnabled:<bool>,foo:{total:<number>}})");
+      expect(format(result)).to.equal('shape({isEnabled:<bool>,foo:{total:<number>}})');
     });
   });
 });

--- a/test/PropTypeValidator.test.js
+++ b/test/PropTypeValidator.test.js
@@ -1,26 +1,26 @@
-import React from "react";
-import { expect } from "chai";
-import ReactSchema from "../src";
+import { expect } from 'chai';
+import ReactSchema from '../src';
+import PropTypes from '../src/PropTypes';
 
-describe("PropTypeValidator", () => {
-  it("is valid", () => {
+describe('PropTypeValidator', () => {
+  it('is valid', () => {
     const propTypes = {
-      myBool: React.PropTypes.bool,
-      myString: React.PropTypes.string,
-      myNumber: React.PropTypes.number
+      myBool: PropTypes.bool,
+      myString: PropTypes.string,
+      myNumber: PropTypes.number,
     };
-    const result = ReactSchema.validate(propTypes, { myBool: true, myString: "Foo", myNumber: 123 });
+    const result = ReactSchema.validate(propTypes, { myBool: true, myString: 'Foo', myNumber: 123 });
     expect(result.isValid).to.equal(true);
   });
 
-  it("is not valid (passes optional component name)", () => {
-    const result = ReactSchema.validate({ isEnabled: React.PropTypes.bool }, { isEnabled:123 }, "MyComponent");
+  it('is not valid (passes optional component name)', () => {
+    const result = ReactSchema.validate({ isEnabled: PropTypes.bool }, { isEnabled: 123 }, 'MyComponent');
     expect(result.isValid).to.equal(false);
-    expect(result.errors.isEnabled.message).to.contain("MyComponent");
+    expect(result.errors.isEnabled.message).to.contain('MyComponent');
   });
 
-  it("validates a single propType", () => {
-    expect(ReactSchema.validate(React.PropTypes.bool, true).isValid).to.equal(true);
-    expect(ReactSchema.validate(React.PropTypes.bool, 123).isValid).to.equal(false);
+  it('validates a single propType', () => {
+    expect(ReactSchema.validate(PropTypes.bool, true).isValid).to.equal(true);
+    expect(ReactSchema.validate(PropTypes.bool, 123).isValid).to.equal(false);
   });
 });

--- a/test/PropTypes.test.js
+++ b/test/PropTypes.test.js
@@ -1,47 +1,46 @@
-import React from "react";
-import { expect } from "chai";
-import { format } from "../src/PropTypeFormatter";
-import PropTypes from "../src/PropTypes";
+import { expect } from 'chai';
+import { format } from '../src/PropTypeFormatter';
+import PropTypes from '../src/PropTypes';
 
-describe("React PropTypes", () => {
-  it("exposes all React prop-types", () => {
-    Object.keys(React.PropTypes).forEach((key) => {
+describe('React PropTypes', () => {
+  it('exposes all React prop-types', () => {
+    Object.keys(PropTypes).forEach((key) => {
       expect(PropTypes[key]).to.be.an.instanceof(Function);
     });
   });
 
-  describe("PropTypes.oneOf", () => {
-    it("stores enum values on return object", () => {
+  describe('PropTypes.oneOf', () => {
+    it('stores enum values on return object', () => {
       const result = PropTypes.oneOf(['one', 'two']);
       expect(result.$meta.args).to.eql(['one', 'two']);
     });
 
-    it("stores enum values on the corresponding `isRequired` object", () => {
+    it('stores enum values on the corresponding `isRequired` object', () => {
       const result = PropTypes.oneOf(['one', 'two']);
       expect(result.isRequired.$meta.args).to.eql(['one', 'two']);
     });
   });
 
 
-  describe("PropTypes.oneOfType", () => {
-    it("stores type values on return object", () => {
-      const result = PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.number]);
-      expect(result.$meta.args).to.eql([React.PropTypes.string, React.PropTypes.number]);
+  describe('PropTypes.oneOfType', () => {
+    it('stores type values on return object', () => {
+      const result = PropTypes.oneOfType([PropTypes.string, PropTypes.number]);
+      expect(result.$meta.args).to.eql([PropTypes.string, PropTypes.number]);
     });
 
-    it("stores type values on the corresponding `isRequired` object", () => {
-      const result = PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.number]);
-      expect(result.isRequired.$meta.args).to.eql([React.PropTypes.string, React.PropTypes.number]);
+    it('stores type values on the corresponding `isRequired` object', () => {
+      const result = PropTypes.oneOfType([PropTypes.string, PropTypes.number]);
+      expect(result.isRequired.$meta.args).to.eql([PropTypes.string, PropTypes.number]);
     });
   });
 
-  describe("PropTypes.shape", () => {
-    it("stores the shape on the return object", () => {
+  describe('PropTypes.shape', () => {
+    it('stores the shape on the return object', () => {
       const result = PropTypes.shape({ isEnabled: PropTypes.bool });
       expect(result.$meta.args).to.eql({ isEnabled: PropTypes.bool });
     });
 
-    it("stores the shape on the corresponding `isRequired` object", () => {
+    it('stores the shape on the corresponding `isRequired` object', () => {
       const result = PropTypes.shape({ isEnabled: PropTypes.bool });
       expect(result.isRequired.$meta.args).to.eql({ isEnabled: PropTypes.bool });
     });

--- a/test/utils/getTypeName.test.js
+++ b/test/utils/getTypeName.test.js
@@ -1,42 +1,41 @@
-import subject from "../../src/utils/getTypeName";
-import { expect } from "chai";
-import React from "react";
-import PropTypes from "../../src/PropTypes";
+import subject from '../../src/utils/getTypeName';
+import { expect } from 'chai';
+import PropTypes from '../../src/PropTypes';
 
-describe("utils::getTypeName", () => {
-  context('given a nilly', function() {
-    it('returns undefined', function() {
+describe('utils::getTypeName', () => {
+  context('given a nilly', function () {
+    it('returns undefined', function () {
       expect(subject()).to.equal(undefined);
     });
   });
 
-  context('given an introspectable checker', function() {
-    it('returns its pre-defined type', function() {
+  context('given an introspectable checker', function () {
+    it('returns its pre-defined type', function () {
       expect(subject({ $meta: { type: 'foo' } })).to.equal('foo');
     });
   });
 
-  describe('pre-defined types in PropTypes or React.PropTypes', function() {
-    context('given React.PropTypes.string', function() {
-      it('returns "string"', function() {
-        expect(subject(React.PropTypes.string)).to.equal('string');
-      });
-    });
-
-    context('given React.PropTypes.string.isRequired', function() {
-      it('returns "string"', function() {
-        expect(subject(React.PropTypes.string.isRequired)).to.equal('string');
-      });
-    });
-
-    context('given PropTypes.string', function() {
-      it('returns "string"', function() {
+  describe('pre-defined types in PropTypes', function () {
+    context('given PropTypes.string', function () {
+      it('returns "string"', function () {
         expect(subject(PropTypes.string)).to.equal('string');
       });
     });
 
-    context('given PropTypes.string.isRequired', function() {
-      it('returns "string"', function() {
+    context('given PropTypes.string.isRequired', function () {
+      it('returns "string"', function () {
+        expect(subject(PropTypes.string.isRequired)).to.equal('string');
+      });
+    });
+
+    context('given PropTypes.string', function () {
+      it('returns "string"', function () {
+        expect(subject(PropTypes.string)).to.equal('string');
+      });
+    });
+
+    context('given PropTypes.string.isRequired', function () {
+      it('returns "string"', function () {
         expect(subject(PropTypes.string.isRequired)).to.equal('string');
       });
     });


### PR DESCRIPTION
I included one of the forks of React.PropTypes, added support for symbol (1 line, untested), and replaced all references to React. It passes all existing tests.

I looked at the latest version of React.PropTypes in the React repo, but it had several external dependencies which are not in the fork that I used. I think this one is recent enough, has all the needed prop types, and is compatible.
